### PR TITLE
Rename toSpatialOblivious_ to toSpatialReduce

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/Implicits.scala
@@ -40,9 +40,9 @@ trait Implicits {
     M[_]
   ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialMethods[K, V, M]
 
-  implicit class withSpaceTimeToSpatialMethodsOblivious[
+  implicit class withSpaceTimeToSpatialReduceMethods[
     K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
     V: ClassTag,
     M[_]
-  ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialObliviousMethods[K, V, M]
+  ](val self: RDD[(K, V)] with Metadata[M[K]]) extends SpaceTimeToSpatialReduceMethods[K, V, M]
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/SpaceTimeToSpatialMethods.scala
@@ -38,6 +38,9 @@ abstract class SpaceTimeToSpatialMethods[
 
   def toSpatial(dateTime: ZonedDateTime): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
     toSpatial(dateTime.toInstant.toEpochMilli)
+
+  def toSpatial(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+    ToSpatial(self)
 }
 
 /**
@@ -47,18 +50,21 @@ abstract class SpaceTimeToSpatialMethods[
   * can be named `toSpatial` as that would hide the methods provided
   * by the class above.
   */
-abstract class SpaceTimeToSpatialObliviousMethods[
+abstract class SpaceTimeToSpatialReduceMethods[
   K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
   V: ClassTag,
   M[_]
 ] extends MethodExtensions[RDD[(K, V)] with Metadata[M[K]]] {
 
-  def toSpatialObliviousUnique(
-    mergeFunc: Option[(V, V) => V] = None,
-    partitioner: Option[Partitioner] = None
+  def toSpatialReduce(
+    mergeFunc: (V, V) => V
   ): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
-    ToSpatial(self, mergeFunc, partitioner)
+    ToSpatial(self, Some(mergeFunc), None)
 
-  def toSpatialObliviousNonUnique(): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
-    ToSpatial(self)
+  def toSpatialReduce(
+    mergeFunc: (V, V) => V,
+    partitioner: Partitioner
+  ): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] =
+    ToSpatial(self, Some(mergeFunc), Some(partitioner))
+
 }

--- a/spark/src/main/scala/geotrellis/spark/filter/ToSpatial.scala
+++ b/spark/src/main/scala/geotrellis/spark/filter/ToSpatial.scala
@@ -125,8 +125,8 @@ object ToSpatial {
   }
 
   def apply[
-    K: ClassTag: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
-    V: ClassTag,
+    K: SpatialComponent: TemporalComponent: λ[α => M[α] => Functor[M, α]]: λ[α => Component[M[α], Bounds[α]]],
+    V,
     M[_]
   ](rdd: RDD[(K, V)] with Metadata[M[K]]): RDD[(SpatialKey, V)] with Metadata[M[SpatialKey]] = {
     val metadata = rdd.metadata.map(_.getComponent[SpatialKey])

--- a/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/filter/TileLayerRDDFilterMethodsSpec.scala
@@ -66,12 +66,12 @@ class TileLayerRDDFilterMethodsSpec extends FunSpec with TestEnvironment {
     }
 
     it ("should obliviously drop the temporal dimension when requested to do so (non-unique)") {
-      val spatial = tileLayerRdd.toSpatialObliviousNonUnique()
+      val spatial = tileLayerRdd.toSpatial()
       spatial.count should be (10)
     }
 
     it ("should obliviously drop the temporal dimension when requested to do so (unique)") {
-      val spatial = tileLayerRdd.toSpatialObliviousUnique()
+      val spatial = tileLayerRdd.toSpatialReduce((a, b) => a)
       spatial.count should be (4)
     }
 


### PR DESCRIPTION
toSpatialObliviousNonUnique can also be moved to existing method extension because it does not require ClassTag constraints.

Opted to avoid using default parameters in the method extensions because it seems likely that we will want additional methods there, possibly filtering by a range. Multiple methods sharing the same name may not also have default parameters due to name mangling required to create them. At that point having them there will just cause weird binary compatibility concerns.